### PR TITLE
orgchart apis added to create nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Gemfile.lock
 
 # Ignore gem
 *.gem
+.idea

--- a/lib/docebo_ruby.rb
+++ b/lib/docebo_ruby.rb
@@ -3,6 +3,7 @@ require 'docebo_ruby/api'
 require 'docebo_ruby/parameters'
 require 'docebo_ruby/resource'
 require 'docebo_ruby/course'
+require 'docebo_ruby/orgchart'
 require 'docebo_ruby/user'
 
 module DoceboRuby

--- a/lib/docebo_ruby/orgchart.rb
+++ b/lib/docebo_ruby/orgchart.rb
@@ -1,0 +1,10 @@
+module DoceboRuby
+  class Orgchart < Resource
+    self.api = 'orgchart'
+    class << self
+      def create_node(attributes = {})
+        fetch_data('createNode', attributes)
+      end
+    end
+  end
+end

--- a/lib/docebo_ruby/parameters.rb
+++ b/lib/docebo_ruby/parameters.rb
@@ -1,7 +1,7 @@
 module DoceboRuby
   class Parameters
     def initialize(hash)
-      @hash = hash.sort.to_h
+      @hash = hash.to_h
     end
 
     def to_s

--- a/spec/fixtures/docebo/orgchart/create_node/success.json
+++ b/spec/fixtures/docebo/orgchart/create_node/success.json
@@ -1,0 +1,1 @@
+{ "success":true, "org_id": 123 }

--- a/spec/lib/docebo_ruby/orgchart_spec.rb
+++ b/spec/lib/docebo_ruby/orgchart_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe DoceboRuby::Orgchart do
+  it 'wraps up Docebo LMS Orgchart' do
+    expect(DoceboRuby::Orgchart.api).to eq 'orgchart'
+  end
+
+  describe '.create' do
+    context 'valid params' do
+      it 'creates node at docebo' do
+        result = DoceboRuby::Orgchart.create_node\
+                   code: 'FirstNode123',
+                   translation: { english: 'First Node' }
+
+        expect(result['success']).to be_truthy
+        expect(result['org_id']).to eq 123
+      end
+    end
+  end
+end

--- a/spec/lib/docebo_ruby/parameters_spec.rb
+++ b/spec/lib/docebo_ruby/parameters_spec.rb
@@ -8,7 +8,7 @@ describe DoceboRuby do
     end
 
     it 'joins hash values by comma' do
-      expect(parameters.to_s).to eq '2,1'
+      expect(parameters.to_s).to eq '1,2'
     end
   end
 end

--- a/spec/lib/docebo_ruby/user_spec.rb
+++ b/spec/lib/docebo_ruby/user_spec.rb
@@ -48,7 +48,10 @@ describe DoceboRuby::Resource do
   describe '.sso_url' do
     it 'generates SSO URL based on username' do
       expect(DoceboRuby::User.sso_url 'jack')
-        .to match /auth_regen=1&login_user=jack/
+        .to match /auth_regen=1/
+
+      expect(DoceboRuby::User.sso_url 'jack')
+        .to match /login_user=jack/
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,5 +46,11 @@ RSpec.configure do |config|
         status: 200,
         body: File.new('spec/fixtures/docebo/user/authenticate/failure.json')
       )
+    stub_request(:post, 'example.com/orgchart/createNode')
+      .with(body: {code: 'FirstNode123', translation: { english: 'First Node'}})
+      .to_return(
+        status: 200,
+        body: File.new('spec/fixtures/docebo/orgchart/create_node/success.json')
+      )
   end
 end


### PR DESCRIPTION
- Removed sorting on params as it was failing for array type params required for node creation e.g. `translation[english]`
- Fixed failing test `enerates SSO URL based on username`
- Node creation APIs added
